### PR TITLE
workflowInstanceKey data type changed to string from long

### DIFF
--- a/src/main/java/org/apache/fineract/operations/TransactionRequest.java
+++ b/src/main/java/org/apache/fineract/operations/TransactionRequest.java
@@ -20,7 +20,7 @@ import static org.apache.fineract.operations.TransactionRequestState.IN_PROGRESS
 public class TransactionRequest extends AbstractPersistableCustom<Long> {
 
     @Column(name = "WORKFLOW_INSTANCE_KEY")
-    private Long workflowInstanceKey;
+    private String workflowInstanceKey;
 
     @Column(name = "TRANSACTION_ID")
     private String transactionId;
@@ -78,16 +78,16 @@ public class TransactionRequest extends AbstractPersistableCustom<Long> {
     public TransactionRequest() {
     }
 
-    public TransactionRequest(Long workflowInstanceKey) {
+    public TransactionRequest(String workflowInstanceKey) {
         this.workflowInstanceKey = workflowInstanceKey;
         this.state = IN_PROGRESS;
     }
 
-    public Long getWorkflowInstanceKey() {
+    public String getWorkflowInstanceKey() {
         return workflowInstanceKey;
     }
 
-    public void setWorkflowInstanceKey(Long workflowInstanceKey) {
+    public void setWorkflowInstanceKey(String workflowInstanceKey) {
         this.workflowInstanceKey = workflowInstanceKey;
     }
 


### PR DESCRIPTION
Below is the new response after this change. Check the field `"workflowInstanceKey": "2251799813758300"`, earlier it was `Long` now it is changed to `String`.

```JSON
{
    "content": [
        {
            "id": 2,
            "workflowInstanceKey": "2251799813758300",
            "transactionId": "f4b8af41495dzacDhuEp",
            "startedAt": 1646121561000,
            "completedAt": null,
            "state": "FAILED",
            "payeeDfspId": null,
            "payeePartyId": "27930998",
            "payeePartyIdType": "ACCOUNTID",
            "payeeFee": null,
            "payeeQuoteCode": null,
            "payerDfspId": null,
            "payerPartyId": "254712087927",
            "payerPartyIdType": "MSISDN",
            "payerFee": null,
            "payerQuoteCode": null,
            "amount": 1,
            "currency": "KES",
            "direction": "INCOMING",
            "authType": null,
            "initiatorType": "BUSINESS",
            "scenario": "MPESA"
        }
    ],
    "totalPages": 1,
    "totalElements": 2,
    "last": true,
    "numberOfElements": 2,
    "sort": [
        {
            "direction": "DESC",
            "property": "startedAt",
            "ignoreCase": false,
            "nullHandling": "NATIVE",
            "descending": true,
            "ascending": false
        }
    ],
    "first": true,
    "size": 20,
    "number": 0
}
```