### PR TITLE
New endpoint implemented /transactionRequests/export for exporting filter based transaction request data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'com.googlecode.flyway:flyway-core:2.1.1'
     implementation 'net.sf.ehcache:ehcache:2.10.6'
     testImplementation 'junit:junit:4.11'
+    implementation 'net.sf.supercsv:super-csv:2.4.0'
 }
 
 group = 'org.apache.fineract'

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,11 @@
             <version>4.11</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.sf.supercsv</groupId>
+            <artifactId>super-csv</artifactId>
+            <version>2.4.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/apache/fineract/api/OperationsDetailedApi.java
+++ b/src/main/java/org/apache/fineract/api/OperationsDetailedApi.java
@@ -16,8 +16,11 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.net.URLDecoder;
-import java.util.*;
-
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.List;
 import static org.apache.fineract.core.service.OperatorUtils.dateFormat;
 
 

--- a/src/main/java/org/apache/fineract/data/ErrorCode.java
+++ b/src/main/java/org/apache/fineract/data/ErrorCode.java
@@ -1,0 +1,11 @@
+package org.apache.fineract.data;
+
+public enum ErrorCode {
+    CSV_GET_WRITER,
+    CSV_WRITE_HEADER,
+    CSV_WRITE_DATA,
+    CSV_STREAM,
+    CSV_BUILDER,
+    INVALID_FILTER,
+    FILTER_ID
+}

--- a/src/main/java/org/apache/fineract/exception/CsvWriterException.java
+++ b/src/main/java/org/apache/fineract/exception/CsvWriterException.java
@@ -1,5 +1,7 @@
 package org.apache.fineract.exception;
 
+import org.apache.fineract.data.ErrorCode;
+
 public class CsvWriterException extends WriteToCsvException{
 
     public CsvWriterException(ErrorCode errorCode, String errorDescription) {

--- a/src/main/java/org/apache/fineract/exception/CsvWriterException.java
+++ b/src/main/java/org/apache/fineract/exception/CsvWriterException.java
@@ -1,0 +1,9 @@
+package org.apache.fineract.exception;
+
+public class CsvWriterException extends WriteToCsvException{
+
+    public CsvWriterException(ErrorCode errorCode, String errorDescription) {
+        super(errorCode, errorDescription);
+    }
+
+}

--- a/src/main/java/org/apache/fineract/exception/WriteToCsvException.java
+++ b/src/main/java/org/apache/fineract/exception/WriteToCsvException.java
@@ -1,0 +1,56 @@
+package org.apache.fineract.exception;
+
+import java.io.IOException;
+
+public class WriteToCsvException extends Exception {
+
+    private String developerMessage;
+    private final String errorDescription;
+    private final ErrorCode errorCode;
+
+    public WriteToCsvException(ErrorCode errorCode, String errorDescription, String developerMessage) {
+        super(developerMessage);
+        this.errorCode = errorCode;
+        this.errorDescription = errorDescription;
+        this.developerMessage = developerMessage;
+    }
+
+    public WriteToCsvException(ErrorCode errorCode, String errorDescription) {
+        super(errorDescription);
+        this.errorCode = errorCode;
+        this.errorDescription = errorDescription;
+        this.developerMessage = errorDescription;
+    }
+
+    public void setDeveloperMessage(String developerMessage) {
+        this.developerMessage = developerMessage;
+    }
+
+    public String getErrorCode() {
+        return errorCode.name();
+    }
+
+    public String getErrorDescription() {
+        return errorDescription;
+    }
+
+    public String getDeveloperMessage() { return developerMessage; }
+
+    @Override
+    public String toString() {
+        return "{" +
+                "developerMessage='" + developerMessage + '\'' +
+                ", errorDescription='" + errorDescription + '\'' +
+                ", errorCode=" + errorCode +
+                '}';
+    }
+
+    public enum ErrorCode {
+        CSV_GET_WRITER,
+        CSV_WRITE_HEADER,
+        CSV_WRITE_DATA,
+        CSV_STREAM,
+        CSV_BUILDER
+    }
+
+}

--- a/src/main/java/org/apache/fineract/exception/WriteToCsvException.java
+++ b/src/main/java/org/apache/fineract/exception/WriteToCsvException.java
@@ -1,6 +1,6 @@
 package org.apache.fineract.exception;
 
-import java.io.IOException;
+import org.apache.fineract.data.ErrorCode;
 
 public class WriteToCsvException extends Exception {
 
@@ -43,14 +43,6 @@ public class WriteToCsvException extends Exception {
                 ", errorDescription='" + errorDescription + '\'' +
                 ", errorCode=" + errorCode +
                 '}';
-    }
-
-    public enum ErrorCode {
-        CSV_GET_WRITER,
-        CSV_WRITE_HEADER,
-        CSV_WRITE_DATA,
-        CSV_STREAM,
-        CSV_BUILDER
     }
 
 }

--- a/src/main/java/org/apache/fineract/operations/Filter.java
+++ b/src/main/java/org/apache/fineract/operations/Filter.java
@@ -1,0 +1,9 @@
+package org.apache.fineract.operations;
+
+public enum Filter {
+    TRANSACTIONID,
+    PAYERID,
+    PAYEEID,
+    EXTERNALID,
+    WORKFLOWINSTANCEKEY
+}

--- a/src/main/java/org/apache/fineract/operations/TransactionRequestSpecs.java
+++ b/src/main/java/org/apache/fineract/operations/TransactionRequestSpecs.java
@@ -1,9 +1,13 @@
 package org.apache.fineract.operations;
 
+import org.springframework.data.jpa.domain.JpaSort;
 import org.springframework.data.jpa.domain.Specifications;
 
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Path;
 import javax.persistence.metamodel.SingularAttribute;
 import java.util.Date;
+import java.util.List;
 
 import static org.springframework.data.jpa.domain.Specifications.where;
 
@@ -27,5 +31,16 @@ public class TransactionRequestSpecs {
 
     public static <T> Specifications<TransactionRequest> match(SingularAttribute<TransactionRequest, T> attribute, T input) {
         return where((root, query, builder) -> builder.equal(root.get(attribute), input));
+    }
+
+    public static <T> Specifications<TransactionRequest> in(SingularAttribute<TransactionRequest, T> attribute, List<T> inputs) {
+        return where(((root, query, cb) -> {
+            final Path<T> group = root.get(attribute);
+            CriteriaBuilder.In<T> cr = cb.in(group);
+            for(T input: inputs ) {
+                cr.value(input);
+            }
+            return cr;
+        }));
     }
 }

--- a/src/main/java/org/apache/fineract/utils/CsvUtility.java
+++ b/src/main/java/org/apache/fineract/utils/CsvUtility.java
@@ -1,8 +1,6 @@
 package org.apache.fineract.utils;
 
 import org.apache.fineract.exception.WriteToCsvException;
-import org.apache.fineract.operations.TransactionRequest;
-
 import javax.servlet.http.HttpServletResponse;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -11,14 +9,7 @@ import java.util.List;
 
 public class CsvUtility {
 
-    public static String[] transactionRequestsFields = {
-            "workflowInstanceKey", "transactionId", "startedAt", "completedAt",
-            "state", "payeeDfspId", "payeePartyId", "payeePartyIdType",
-            "payeeFee", "payeeQuoteCode", "payerDfspId", "payerPartyId",
-            "payerPartyIdType", "payerFee", "payerQuoteCode", "amount",
-            "currency", "direction", "authType", "initiatorType", "scenario"};
-
-    public static void writeToCsv(HttpServletResponse response, List<TransactionRequest> transactionRequests) throws WriteToCsvException {
+    public static <T> void writeToCsv(HttpServletResponse response, List<T> listOfData) throws WriteToCsvException {
         response.setContentType("text/csv");
         DateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
         String currentDateTime = dateFormatter.format(new Date());
@@ -27,26 +18,12 @@ public class CsvUtility {
         String headerValue = "attachment; filename=" + filename;
         response.setHeader(headerKey, headerValue);
 
-        CsvWriter<TransactionRequest> writer = new CsvWriter.Builder<TransactionRequest>()
-                .setHeader(getCsvHeader(transactionRequestsFields))
-                .setNameMapping(transactionRequestsFields)
+        CsvWriter<T> writer = new CsvWriter.Builder<T>()
                 .setPrintWriter(response)
-                .setData(transactionRequests)
+                .setData(listOfData)
                 .build();
 
         writer.write();
-    }
-
-    /**
-     * creates the csv header based on the fields provided
-     * @return csv header of type String array
-     */
-    private static String[] getCsvHeader(String[] fields) {
-        String[] csvHeader = new String[fields.length];
-        for (int i = 0; i < fields.length; i++) {
-            csvHeader[i] = fields[i].toUpperCase();
-        }
-        return csvHeader;
     }
 
 }

--- a/src/main/java/org/apache/fineract/utils/CsvUtility.java
+++ b/src/main/java/org/apache/fineract/utils/CsvUtility.java
@@ -1,11 +1,9 @@
 package org.apache.fineract.utils;
 
+import org.apache.fineract.exception.WriteToCsvException;
 import org.apache.fineract.operations.TransactionRequest;
-import org.supercsv.io.CsvBeanWriter;
-import org.supercsv.io.ICsvBeanWriter;
-import org.supercsv.prefs.CsvPreference;
+
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -13,7 +11,14 @@ import java.util.List;
 
 public class CsvUtility {
 
-    public static void writeToCsv(HttpServletResponse response, List<TransactionRequest> transactionRequests) throws IOException {
+    public static String[] transactionRequestsFields = {
+            "workflowInstanceKey", "transactionId", "startedAt", "completedAt",
+            "state", "payeeDfspId", "payeePartyId", "payeePartyIdType",
+            "payeeFee", "payeeQuoteCode", "payerDfspId", "payerPartyId",
+            "payerPartyIdType", "payerFee", "payerQuoteCode", "amount",
+            "currency", "direction", "authType", "initiatorType", "scenario"};
+
+    public static void writeToCsv(HttpServletResponse response, List<TransactionRequest> transactionRequests) throws WriteToCsvException {
         response.setContentType("text/csv");
         DateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
         String currentDateTime = dateFormatter.format(new Date());
@@ -22,22 +27,26 @@ public class CsvUtility {
         String headerValue = "attachment; filename=" + filename;
         response.setHeader(headerKey, headerValue);
 
-        ICsvBeanWriter csvWriter = new CsvBeanWriter(response.getWriter(), CsvPreference.STANDARD_PREFERENCE);
-        String[] nameMapping = {
-                "workflowInstanceKey", "transactionId", "startedAt", "completedAt",
-                "state", "payeeDfspId", "payeePartyId", "payeePartyIdType",
-                "payeeFee", "payeeQuoteCode", "payerDfspId", "payerPartyId",
-                "payerPartyIdType", "payerFee", "payerQuoteCode", "amount",
-                "currency", "direction", "authType", "initiatorType", "scenario"};
-        String[] csvHeader = new String[nameMapping.length];
-        for (int i = 0; i < nameMapping.length; i++) {
-            csvHeader[i] = nameMapping[i].toUpperCase();
+        CsvWriter<TransactionRequest> writer = new CsvWriter.Builder<TransactionRequest>()
+                .setHeader(getCsvHeader(transactionRequestsFields))
+                .setNameMapping(transactionRequestsFields)
+                .setPrintWriter(response)
+                .setData(transactionRequests)
+                .build();
+
+        writer.write();
+    }
+
+    /**
+     * creates the csv header based on the fields provided
+     * @return csv header of type String array
+     */
+    private static String[] getCsvHeader(String[] fields) {
+        String[] csvHeader = new String[fields.length];
+        for (int i = 0; i < fields.length; i++) {
+            csvHeader[i] = fields[i].toUpperCase();
         }
-        csvWriter.writeHeader(csvHeader);
-        for (TransactionRequest user : transactionRequests) {
-            csvWriter.write(user, nameMapping);
-        }
-        csvWriter.close();
+        return csvHeader;
     }
 
 }

--- a/src/main/java/org/apache/fineract/utils/CsvUtility.java
+++ b/src/main/java/org/apache/fineract/utils/CsvUtility.java
@@ -1,0 +1,43 @@
+package org.apache.fineract.utils;
+
+import org.apache.fineract.operations.TransactionRequest;
+import org.supercsv.io.CsvBeanWriter;
+import org.supercsv.io.ICsvBeanWriter;
+import org.supercsv.prefs.CsvPreference;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+public class CsvUtility {
+
+    public static void writeToCsv(HttpServletResponse response, List<TransactionRequest> transactionRequests) throws IOException {
+        response.setContentType("text/csv");
+        DateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
+        String currentDateTime = dateFormatter.format(new Date());
+        String filename = "transactionRequest_" + currentDateTime + ".csv";
+        String headerKey = "Content-Disposition";
+        String headerValue = "attachment; filename=" + filename;
+        response.setHeader(headerKey, headerValue);
+
+        ICsvBeanWriter csvWriter = new CsvBeanWriter(response.getWriter(), CsvPreference.STANDARD_PREFERENCE);
+        String[] nameMapping = {
+                "workflowInstanceKey", "transactionId", "startedAt", "completedAt",
+                "state", "payeeDfspId", "payeePartyId", "payeePartyIdType",
+                "payeeFee", "payeeQuoteCode", "payerDfspId", "payerPartyId",
+                "payerPartyIdType", "payerFee", "payerQuoteCode", "amount",
+                "currency", "direction", "authType", "initiatorType", "scenario"};
+        String[] csvHeader = new String[nameMapping.length];
+        for (int i = 0; i < nameMapping.length; i++) {
+            csvHeader[i] = nameMapping[i].toUpperCase();
+        }
+        csvWriter.writeHeader(csvHeader);
+        for (TransactionRequest user : transactionRequests) {
+            csvWriter.write(user, nameMapping);
+        }
+        csvWriter.close();
+    }
+
+}

--- a/src/main/java/org/apache/fineract/utils/CsvWriter.java
+++ b/src/main/java/org/apache/fineract/utils/CsvWriter.java
@@ -1,5 +1,6 @@
 package org.apache.fineract.utils;
 
+import org.apache.fineract.data.ErrorCode;
 import org.apache.fineract.exception.CsvWriterException;
 import org.apache.fineract.exception.WriteToCsvException;
 import org.supercsv.io.CsvBeanWriter;
@@ -48,7 +49,7 @@ public class CsvWriter<T> {
      */
     private void writeCsvHeaders(String[] csvHeader) throws WriteToCsvException {
         performErrorProneTask(
-                new WriteToCsvException(WriteToCsvException.ErrorCode.CSV_WRITE_HEADER, "Unable to write csv headers"),
+                new WriteToCsvException(ErrorCode.CSV_WRITE_HEADER, "Unable to write csv headers"),
                 () -> {
                     iCsvBeanWriter.writeHeader(csvHeader);
                     return null;
@@ -64,7 +65,7 @@ public class CsvWriter<T> {
     private void writeData(String[] nameMapping, List<T> objects) throws WriteToCsvException {
         for(T data: objects) {
             performErrorProneTask(
-                    new WriteToCsvException(WriteToCsvException.ErrorCode.CSV_WRITE_DATA, "Unable to write csv headers"),
+                    new WriteToCsvException(ErrorCode.CSV_WRITE_DATA, "Unable to write csv headers"),
                     () -> {
                         iCsvBeanWriter.write(data, nameMapping);
                         return null;
@@ -78,7 +79,7 @@ public class CsvWriter<T> {
      */
     private void closeStream() throws WriteToCsvException {
         performErrorProneTask(
-                new WriteToCsvException(WriteToCsvException.ErrorCode.CSV_STREAM, "Unable to close/flush stream"),
+                new WriteToCsvException(ErrorCode.CSV_STREAM, "Unable to close/flush stream"),
                 () -> {
                     iCsvBeanWriter.close();
                     return null;
@@ -113,7 +114,7 @@ public class CsvWriter<T> {
         public Builder<T> setPrintWriter(HttpServletResponse response) throws WriteToCsvException {
             this.printWriter = performErrorProneTask(
                     new WriteToCsvException(
-                            WriteToCsvException.ErrorCode.CSV_GET_WRITER,
+                            ErrorCode.CSV_GET_WRITER,
                             "Unable to create csv bean writer instance"),
                     response::getWriter) ;
             return this;
@@ -142,16 +143,16 @@ public class CsvWriter<T> {
 
         public CsvWriter<T> build() throws CsvWriterException {
             if(printWriter == null) {
-                throw new CsvWriterException(WriteToCsvException.ErrorCode.CSV_BUILDER,"Print writer can't be null");
+                throw new CsvWriterException(ErrorCode.CSV_BUILDER,"Print writer can't be null");
             }
             if(csvHeader == null) {
-                throw new CsvWriterException(WriteToCsvException.ErrorCode.CSV_BUILDER,"Csv header can't be null");
+                throw new CsvWriterException(ErrorCode.CSV_BUILDER,"Csv header can't be null");
             }
             if(data == null) {
-                throw new CsvWriterException(WriteToCsvException.ErrorCode.CSV_BUILDER,"Data can't be null");
+                throw new CsvWriterException(ErrorCode.CSV_BUILDER,"Data can't be null");
             }
             if(nameMapping == null) {
-                throw new CsvWriterException(WriteToCsvException.ErrorCode.CSV_BUILDER, "Name mapping can't be null");
+                throw new CsvWriterException(ErrorCode.CSV_BUILDER, "Name mapping can't be null");
             }
             return new CsvWriter<>(printWriter, csvHeader, data, nameMapping);
         }

--- a/src/main/java/org/apache/fineract/utils/CsvWriter.java
+++ b/src/main/java/org/apache/fineract/utils/CsvWriter.java
@@ -1,0 +1,160 @@
+package org.apache.fineract.utils;
+
+import org.apache.fineract.exception.CsvWriterException;
+import org.apache.fineract.exception.WriteToCsvException;
+import org.supercsv.io.CsvBeanWriter;
+import org.supercsv.io.ICsvBeanWriter;
+import org.supercsv.prefs.CsvPreference;
+import javax.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
+import java.util.List;
+
+/**
+ * custom csv writer for writing list of POJOs into printer of HttpServletResponse
+ * @param <T> generic type representing the data type of POJO
+ */
+public class CsvWriter<T> {
+
+    interface Callback<T> {
+        T call() throws Exception;
+    }
+
+    private final ICsvBeanWriter iCsvBeanWriter;
+    private final String[] csvHeader;
+    private final List<T> data;
+    private final String[] nameMapping;
+
+    private CsvWriter(PrintWriter printWriter, String[] csvHeader, List<T> data, String[] nameMapping) {
+        this.iCsvBeanWriter = new CsvBeanWriter(printWriter, CsvPreference.STANDARD_PREFERENCE);
+        this.csvHeader = csvHeader;
+        this.data = data;
+        this.nameMapping = nameMapping;
+    }
+
+    /**
+     * writes csv data into printer
+     * @throws WriteToCsvException @see [writeCsvHeaders], [writeData] and [closeStream]
+     */
+    public void write() throws WriteToCsvException {
+        writeCsvHeaders(csvHeader);
+        writeData(nameMapping, data);
+        closeStream();
+    }
+
+    /**
+     * writes the headers into csv
+     * @param csvHeader the headers to be written in csv of type string array
+     * @throws WriteToCsvException @see [performErrorProneTask]
+     */
+    private void writeCsvHeaders(String[] csvHeader) throws WriteToCsvException {
+        performErrorProneTask(
+                new WriteToCsvException(WriteToCsvException.ErrorCode.CSV_WRITE_HEADER, "Unable to write csv headers"),
+                () -> {
+                    iCsvBeanWriter.writeHeader(csvHeader);
+                    return null;
+                });
+    }
+
+    /**
+     * writes the data/ rows in csv
+     * @param nameMapping string array of the fields to be populated from POJO
+     * @param objects list of the objects to be translated into rows in csv
+     * @throws WriteToCsvException @see [performErrorProneTask]
+     */
+    private void writeData(String[] nameMapping, List<T> objects) throws WriteToCsvException {
+        for(T data: objects) {
+            performErrorProneTask(
+                    new WriteToCsvException(WriteToCsvException.ErrorCode.CSV_WRITE_DATA, "Unable to write csv headers"),
+                    () -> {
+                        iCsvBeanWriter.write(data, nameMapping);
+                        return null;
+                    });
+        }
+    }
+
+    /**
+     * Closes the existing [ICsvBeanWriter] stream
+     * @throws WriteToCsvException @see [performErrorProneTask]
+     */
+    private void closeStream() throws WriteToCsvException {
+        performErrorProneTask(
+                new WriteToCsvException(WriteToCsvException.ErrorCode.CSV_STREAM, "Unable to close/flush stream"),
+                () -> {
+                    iCsvBeanWriter.close();
+                    return null;
+                });
+    }
+
+    /**
+     * Use this function to perform the task which are prone to errors along with custom [WriteToCsvException]
+     * instance.
+     * @param exception an instance of [WriteToCsvException], which is to be thrown on error occurred
+     * @param callback the task which needs to be performed under try block
+     * @param <T> generic return type of the successful callback call
+     * @return the result of the successful callback of type [T] or throws an error passed
+     * @throws WriteToCsvException if callbacks throws and exception
+     */
+    public static  <T> T performErrorProneTask(WriteToCsvException exception, Callback<T> callback) throws WriteToCsvException {
+        try {
+            return callback.call();
+        } catch (Exception e) {
+            exception.setStackTrace(e.getStackTrace());
+            exception.setDeveloperMessage(e.getLocalizedMessage());
+            throw exception;
+        }
+    }
+
+    public static class Builder<T> {
+        private PrintWriter printWriter;
+        private String[] csvHeader;
+        private List<T> data;
+        private String[] nameMapping;
+
+        public Builder<T> setPrintWriter(HttpServletResponse response) throws WriteToCsvException {
+            this.printWriter = performErrorProneTask(
+                    new WriteToCsvException(
+                            WriteToCsvException.ErrorCode.CSV_GET_WRITER,
+                            "Unable to create csv bean writer instance"),
+                    response::getWriter) ;
+            return this;
+        }
+
+        public Builder<T> setHeader(String[] header) {
+            this.csvHeader = header;
+            return this;
+        }
+
+        public Builder<T> setData(List<T> data) {
+            this.data = data;
+            return this;
+        }
+
+        public Builder<T> setData(List<T> data, String[] nameMapping) {
+            this.data = data;
+            setNameMapping(nameMapping);
+            return this;
+        }
+
+        public Builder<T> setNameMapping(String[] nameMapping) {
+            this.nameMapping = nameMapping;
+            return this;
+        }
+
+        public CsvWriter<T> build() throws CsvWriterException {
+            if(printWriter == null) {
+                throw new CsvWriterException(WriteToCsvException.ErrorCode.CSV_BUILDER,"Print writer can't be null");
+            }
+            if(csvHeader == null) {
+                throw new CsvWriterException(WriteToCsvException.ErrorCode.CSV_BUILDER,"Csv header can't be null");
+            }
+            if(data == null) {
+                throw new CsvWriterException(WriteToCsvException.ErrorCode.CSV_BUILDER,"Data can't be null");
+            }
+            if(nameMapping == null) {
+                throw new CsvWriterException(WriteToCsvException.ErrorCode.CSV_BUILDER, "Name mapping can't be null");
+            }
+            return new CsvWriter<>(printWriter, csvHeader, data, nameMapping);
+        }
+
+    }
+}


### PR DESCRIPTION
Changelog
1. New endpoint added with below specs
```
HTTP_METHOD: POST
ENDPOINT: transactionRequests/export
COMPLETE_URL: {{host/ingress}}/api/v1/transactionRequests/export
REQUEST_BODY: List<String> (list of ids)
SAMPLE_REQUEST_BODY: [ "70830851a2f3rPVoWj3U", "2251799815274522"]
QUERY_PARAMETERS: {
    "page",  "size" and "sortedOrder" as rest of the convention
    "filterBy": the type of filter we want or the type of ids we want to filter with 
}
SAMPLE_QUERY_PARAM: ?filterBy=workflowinstancekey
```
2. Supported filter: `TRANSACTIONID`, `PAYERID`, `PAYEEID`, `EXTERNALID` and `WORKFLOWINSTANCEKEY`

