### PR TITLE
Fixes #21 Support for errorDescription addded in bulk filter API

### DIFF
--- a/src/main/java/org/apache/fineract/api/OperationsDetailedApi.java
+++ b/src/main/java/org/apache/fineract/api/OperationsDetailedApi.java
@@ -271,7 +271,7 @@ public class OperationsDetailedApi {
                 spec = TransactionRequestSpecs.in(TransactionRequest_.payeePartyId, ids);
                 break;
             case WORKFLOWINSTANCEKEY:
-                spec = TransactionRequestSpecs.in(TransactionRequest_.workflowInstanceKey, parseWorkflowInstanceKey(ids));
+                spec = TransactionRequestSpecs.in(TransactionRequest_.workflowInstanceKey, ids);
                 break;
             case STATE:
                 spec = TransactionRequestSpecs.in(TransactionRequest_.state, parseStates(ids));
@@ -319,21 +319,6 @@ public class OperationsDetailedApi {
             errorDesc.add(String.format("\"%s\"", s));
         }
         return errorDesc;
-    }
-
-    /*
-     * Generate List<Long> of workflowInstanceKey from List<String>
-     */
-    private List<Long> parseWorkflowInstanceKey(List<String> keys) {
-        List<Long> workflowInstanceKeys = new ArrayList<>();
-        for(String key: keys) {
-            try {
-                workflowInstanceKeys.add(Long.parseLong(key));
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
-        return workflowInstanceKeys;
     }
 
     /*

--- a/src/main/java/org/apache/fineract/api/OperationsDetailedApi.java
+++ b/src/main/java/org/apache/fineract/api/OperationsDetailedApi.java
@@ -1,6 +1,5 @@
 package org.apache.fineract.api;
 
-import com.amazonaws.services.dynamodbv2.xspec.S;
 import org.apache.fineract.data.ErrorCode;
 import org.apache.fineract.exception.WriteToCsvException;
 import org.apache.fineract.operations.*;
@@ -308,15 +307,6 @@ public class OperationsDetailedApi {
         }
         return null;
     }
-
-    /*@GetMapping("/test")
-    public List<TransactionRequest> test() {
-        List<String> ec = new ArrayList<>();
-        ec.add("\"AMS Local is disabled\"");
-        List<TransactionRequest> result = transactionRequestRepository.filterByErrorDescription(ec);
-        logger.info("Query response: " + result);
-        return result;
-    }*/
 
     /*
      * Generates the exhaustive errorDescription list by prefixing and suffixing it with double quotes (")

--- a/src/main/java/org/apache/fineract/data/ErrorCode.java
+++ b/src/main/java/org/apache/fineract/data/ErrorCode.java
@@ -7,5 +7,6 @@ public enum ErrorCode {
     CSV_STREAM,
     CSV_BUILDER,
     INVALID_FILTER,
-    FILTER_ID
+    FILTER_ID,
+    EMPTY_RESULT
 }

--- a/src/main/java/org/apache/fineract/operations/Filter.java
+++ b/src/main/java/org/apache/fineract/operations/Filter.java
@@ -6,5 +6,7 @@ public enum Filter {
     PAYEEID,
     EXTERNALID,
     WORKFLOWINSTANCEKEY,
-    STATE
+    STATE,
+
+    ERRORDESCRIPTION
 }

--- a/src/main/java/org/apache/fineract/operations/TransactionRequest.java
+++ b/src/main/java/org/apache/fineract/operations/TransactionRequest.java
@@ -20,7 +20,7 @@ import static org.apache.fineract.operations.TransactionRequestState.IN_PROGRESS
 public class TransactionRequest extends AbstractPersistableCustom<Long> {
 
     @Column(name = "WORKFLOW_INSTANCE_KEY")
-    private String workflowInstanceKey;
+    private Long workflowInstanceKey;
 
     @Column(name = "TRANSACTION_ID")
     private String transactionId;
@@ -78,16 +78,16 @@ public class TransactionRequest extends AbstractPersistableCustom<Long> {
     public TransactionRequest() {
     }
 
-    public TransactionRequest(String workflowInstanceKey) {
+    public TransactionRequest(Long workflowInstanceKey) {
         this.workflowInstanceKey = workflowInstanceKey;
         this.state = IN_PROGRESS;
     }
 
-    public String getWorkflowInstanceKey() {
+    public Long getWorkflowInstanceKey() {
         return workflowInstanceKey;
     }
 
-    public void setWorkflowInstanceKey(String workflowInstanceKey) {
+    public void setWorkflowInstanceKey(Long workflowInstanceKey) {
         this.workflowInstanceKey = workflowInstanceKey;
     }
 

--- a/src/main/java/org/apache/fineract/operations/TransactionRequest.java
+++ b/src/main/java/org/apache/fineract/operations/TransactionRequest.java
@@ -20,7 +20,7 @@ import static org.apache.fineract.operations.TransactionRequestState.IN_PROGRESS
 public class TransactionRequest extends AbstractPersistableCustom<Long> {
 
     @Column(name = "WORKFLOW_INSTANCE_KEY")
-    private Long workflowInstanceKey;
+    private String workflowInstanceKey;
 
     @Column(name = "TRANSACTION_ID")
     private String transactionId;
@@ -78,16 +78,16 @@ public class TransactionRequest extends AbstractPersistableCustom<Long> {
     public TransactionRequest() {
     }
 
-    public TransactionRequest(Long workflowInstanceKey) {
+    public TransactionRequest(String workflowInstanceKey) {
         this.workflowInstanceKey = workflowInstanceKey;
         this.state = IN_PROGRESS;
     }
 
-    public Long getWorkflowInstanceKey() {
+    public String getWorkflowInstanceKey() {
         return workflowInstanceKey;
     }
 
-    public void setWorkflowInstanceKey(Long workflowInstanceKey) {
+    public void setWorkflowInstanceKey(String workflowInstanceKey) {
         this.workflowInstanceKey = workflowInstanceKey;
     }
 

--- a/src/main/java/org/apache/fineract/operations/TransactionRequestRepository.java
+++ b/src/main/java/org/apache/fineract/operations/TransactionRequestRepository.java
@@ -2,9 +2,16 @@ package org.apache.fineract.operations;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface TransactionRequestRepository extends JpaRepository<TransactionRequest, Long>, JpaSpecificationExecutor {
 
     TransactionRequest findFirstByWorkflowInstanceKey(Long workflowInstanceKey);
+
+    @Query("SELECT tr FROM TransactionRequest tr INNER JOIN Variable v ON tr.workflowInstanceKey = v.workflowInstanceKey WHERE v.name=\"errorDescription\" and v.value IN :errorDescription")
+    List<TransactionRequest> filterByErrorDescription(@Param("errorDescription") List<String> errorDescription);
 
 }

--- a/src/main/java/org/apache/fineract/operations/TransactionRequestSpecs.java
+++ b/src/main/java/org/apache/fineract/operations/TransactionRequestSpecs.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.domain.JpaSort;
 import org.springframework.data.jpa.domain.Specifications;
 
 import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Join;
 import javax.persistence.criteria.Path;
 import javax.persistence.metamodel.SingularAttribute;
 import java.util.Date;
@@ -43,4 +44,11 @@ public class TransactionRequestSpecs {
             return cr;
         }));
     }
+
+    /*public static Specifications<TransactionRequest> filterByErrorDescription(List<String> errorDescriptions) {
+        return where(((root, query, cb) -> {
+            Join<TransactionRequest, Variable> txnVariables = root.join(TransactionRequest_.WORKFLOW_INSTANCE_KEY);
+            return cb.equal();
+        }));
+    }*/
 }

--- a/src/main/java/org/apache/fineract/operations/Variable.java
+++ b/src/main/java/org/apache/fineract/operations/Variable.java
@@ -22,7 +22,7 @@ public class Variable extends AbstractPersistableCustom<Long> {
 
     @Column(name = "WORKFLOW_INSTANCE_KEY")
     @Index(name = "idx_workflowInstanceKey")
-    private Long workflowInstanceKey;
+    private String workflowInstanceKey;
 
     @Column(name = "TIMESTAMP")
     private Long timestamp;
@@ -42,11 +42,11 @@ public class Variable extends AbstractPersistableCustom<Long> {
         this.workflowKey = workflowKey;
     }
 
-    public Long getWorkflowInstanceKey() {
+    public String getWorkflowInstanceKey() {
         return workflowInstanceKey;
     }
 
-    public void setWorkflowInstanceKey(Long workflowInstanceKey) {
+    public void setWorkflowInstanceKey(String workflowInstanceKey) {
         this.workflowInstanceKey = workflowInstanceKey;
     }
 

--- a/src/main/java/org/apache/fineract/utils/CsvUtility.java
+++ b/src/main/java/org/apache/fineract/utils/CsvUtility.java
@@ -1,11 +1,15 @@
 package org.apache.fineract.utils;
 
+import org.apache.fineract.data.ErrorCode;
 import org.apache.fineract.exception.WriteToCsvException;
 import javax.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
+
+import static org.apache.fineract.utils.CsvWriter.performErrorProneTask;
 
 public class CsvUtility {
 
@@ -18,11 +22,20 @@ public class CsvUtility {
         String headerValue = "attachment; filename=" + filename;
         response.setHeader(headerKey, headerValue);
 
+        PrintWriter printWriter = performErrorProneTask(
+                new WriteToCsvException(
+                        ErrorCode.CSV_GET_WRITER,
+                        "Unable get writer from HttpServletResponse"),
+                response::getWriter) ;
+
+        //System.out.println("Print writer fetch success");
+
         CsvWriter<T> writer = new CsvWriter.Builder<T>()
-                .setPrintWriter(response)
+                .setPrintWriter(printWriter)
                 .setData(listOfData)
                 .build();
 
+        //System.out.println("Writer object created success");
         writer.write();
     }
 

--- a/src/main/java/org/apache/fineract/utils/CsvWriter.java
+++ b/src/main/java/org/apache/fineract/utils/CsvWriter.java
@@ -6,7 +6,6 @@ import org.apache.fineract.exception.WriteToCsvException;
 import org.supercsv.io.CsvBeanWriter;
 import org.supercsv.io.ICsvBeanWriter;
 import org.supercsv.prefs.CsvPreference;
-import javax.servlet.http.HttpServletResponse;
 import java.io.PrintWriter;
 import java.lang.reflect.Field;
 import java.util.List;
@@ -140,12 +139,8 @@ public class CsvWriter<T> {
         private List<T> data;
         private String[] nameMapping;
 
-        public Builder<T> setPrintWriter(HttpServletResponse response) throws WriteToCsvException {
-            this.printWriter = performErrorProneTask(
-                    new WriteToCsvException(
-                            ErrorCode.CSV_GET_WRITER,
-                            "Unable to create csv bean writer instance"),
-                    response::getWriter) ;
+        public Builder<T> setPrintWriter(PrintWriter printWriter) throws WriteToCsvException {
+            this.printWriter = printWriter;
             return this;
         }
 
@@ -175,9 +170,11 @@ public class CsvWriter<T> {
             if(data == null) {
                 throw new CsvWriterException(ErrorCode.CSV_BUILDER,"Data can't be null");
             }
+            if(data.isEmpty()) {
+                throw new CsvWriterException(ErrorCode.EMPTY_RESULT, "No matching records");
+            }
             if(nameMapping == null) {
                 setNameMapping((Class<T>) this.data.get(0).getClass());
-                throw new CsvWriterException(ErrorCode.CSV_BUILDER, "Name mapping can't be null");
             }
             if(csvHeader == null) {
                 this.csvHeader = getCsvHeader(nameMapping);


### PR DESCRIPTION
This PR includes the below updates
1. New Filter type support added: ERRORDESCRIPTION.
2. `workflowInstanceKey` data type changed to `Long` from `String` in `TransactionRequest` DTO, to support joint query.
3. JPQL query implemented for supporting filter by error description.
4. Bug fixes in `CsvWriter`, a better writer consistency, and fewer errors.
5. Improve code quality of function `filterTransactionRequests` in `OperationsDetailedApi.java`.
 5.1. Handled empty data case.
 5.2. Minor bug fixes.
 5.3. New support for filter `ERRORDESCRIPTION`.