### PR TITLE
[NEOB-1745] Update logback.xml for dynamic log file size and history

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -13,9 +13,9 @@
         <file>logs/console.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/console-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxFileSize>300MB</maxFileSize>
-            <maxHistory>3</maxHistory>
-            <totalSizeCap>950MB</totalSizeCap>
+            <maxFileSize>${LOG_CONSOLE_MAXFILESIZE:-100MB}</maxFileSize>
+            <maxHistory>${LOG_CONSOLE_MAXHISTORY:-7}</maxHistory>
+            <totalSizeCap>${LOG_CONSOLE_TOTALSIZECAP:-300MB}</totalSizeCap>
         </rollingPolicy>
         <encoder>
             <pattern>${CONSOLE_LOG_PATTERN}</pattern>


### PR DESCRIPTION
This commit modifies the logback.xml configuration file to enhance flexibility in log file size and history settings.
Instead of hardcoding values, the configuration now utilizes environment variables for dynamic customization.

Note that maxHistory determines the duration for which files are retained, representing the number of days to keep the files rather than specifying the quantity of files themselves.

