### PR TITLE
[BCB-2428] Integrate JSON logging support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,11 @@
             <artifactId>spring-cloud-starter-aws-secrets-manager-config</artifactId>
             <version>2.4.4</version>
         </dependency>
+		<dependency>
+			<groupId>org.codehaus.janino</groupId>
+			<artifactId>janino</artifactId>
+			<version>3.1.11</version>
+		</dependency>
     </dependencies>
 
     <build>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -2,12 +2,24 @@
 <configuration scan="true">
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
-            <charset>utf8</charset>
-        </encoder>
-    </appender>
+    <springProperty name="jsonLoggingEnabled" source="logging.json.enabled" defaultValue="false"/>
+
+    <if condition="${jsonLoggingEnabled:-false} == true">
+        <then>
+            <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+                <encoder class="ch.qos.logback.classic.encoder.JsonEncoder">
+                </encoder>
+            </appender>
+        </then>
+        <else>
+            <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+                <encoder>
+                    <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+                    <charset>utf8</charset>
+                </encoder>
+            </appender>
+        </else>
+    </if>
 
     <appender name="LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>logs/console.log</file>


### PR DESCRIPTION
Modify logback.xml configuration to conditionally use the Jsonencoder on stdout when the 'logging.json.enabled' property is set to true. The default method is still plain text logging.