### PR TITLE
[GAZ-253] bug fixes for closedloop batch handling, was reporting duplicates and…

### DIFF
--- a/src/main/java/org/apache/fineract/api/BatchApi.java
+++ b/src/main/java/org/apache/fineract/api/BatchApi.java
@@ -336,6 +336,11 @@ public class BatchApi {
         List<Transfer> transfers = null;
         if(batch.getSubBatchId()!=null){
             transfers = transferRepository.findAllByBatchId(batch.getSubBatchId());
+            if (transfers.isEmpty()) {
+                // Closedloop path: transfers are stored under the parent batchId, not the sub-batch ID.
+                // Fall back to parent batchId so sub-batch totals are correctly counted.
+                transfers = transferRepository.findAllByBatchId(batch.getBatchId());
+            }
         }else{
             transfers = transferRepository.findAllByBatchId(batch.getBatchId());
         }

--- a/src/main/java/org/apache/fineract/operations/BatchRepository.java
+++ b/src/main/java/org/apache/fineract/operations/BatchRepository.java
@@ -13,8 +13,13 @@ public interface BatchRepository extends JpaRepository<Batch, Long>, JpaSpecific
 
     Batch findByWorkflowInstanceKey(Long workflowInstanceKey);
 
-    @Query("SELECT bt FROM Batch bt WHERE bt.batchId = :batchId and bt.subBatchId is null")
-    Batch findByBatchId(String batchId);
+    @Query("SELECT bt FROM Batch bt WHERE bt.batchId = :batchId and bt.subBatchId is null ORDER BY bt.id DESC")
+    List<Batch> findParentsByBatchId(String batchId);
+
+    default Batch findByBatchId(String batchId) {
+        List<Batch> results = findParentsByBatchId(batchId);
+        return results.isEmpty() ? null : results.get(0);
+    }
     @Query("SELECT bt FROM Batch bt WHERE bt.batchId = :batchId and bt.subBatchId is not null")
     List<Batch> findAllSubBatchId(String batchId);
 


### PR DESCRIPTION


## Description
Fixes from testing govstack bulk for closedloop and mojaloop on arm and X64_86 => NonUniqueResultException and closedloop transfer lookup

- BatchRepository: Replaces getSingleResult() with a List query (findParentsByBatchId, ordered by id DESC) plus a default method, preventing NonUniqueResultException when duplicate parent rows exist.
- BatchApi.evaluateBatchSummary(): Adds fallback to parent batchId when no transfers are found by sub-batch ID — required because closedloop stores all transfers under the parent batchId, not the sub-batch ID. Fixes status=NULL and completed_at=NULL on completed closedloop batches.

https://mifosforge.jira.com/browse/GAZ-253

* PR title should have jira ticket enclosed in `[]`.<br>
  Format: ``` [jira_ticket] description```<br>
  ex: [phee-123] PR title.
* Add a link to the Jira ticket.
* Describe the changes made and why they were made.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!
- [ ] Followed the PR title naming convention mentioned above.

- [ ] Design related bullet points or design document link related to this PR added in the description above. 

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [ ] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing
