### PR TITLE
[GAZ-253] fix: correct batch status and totals for closedloop transfers

### DIFF
--- a/src/main/java/org/apache/fineract/api/BatchApi.java
+++ b/src/main/java/org/apache/fineract/api/BatchApi.java
@@ -316,7 +316,7 @@ public class BatchApi {
             response.setStatus("COMPLETED");
         } else if (batch.getOngoing() != 0 && batch.getCompletedAt() == null) {
             response.setStatus("Pending");
-        } else if (batch.getFailed().longValue() == batch.getFailed().longValue()) {
+        } else if (batch.getFailed() != null && batch.getFailed() > 0) {
             response.setStatus("Failed");
         } else {
             response.setStatus("UNKNOWN");


### PR DESCRIPTION
## Description
Fixes incorrect batch reporting for closedloop bulk disbursements where
completed batches were showing zero totals and null status in the
operations app.

- **BatchRepository**: Replace `getSingleResult()` with a `List` query
  (`findParentsByBatchId`, ordered by `id DESC`) to prevent
  `NonUniqueResultException` when duplicate parent rows are present
- **BatchApi**: `evaluateBatchSummary()` now falls back to parent
  `batchId` lookup when no transfers are found by sub-batch ID, fixing
  the case where closedloop transfers are stored under the parent batch
  rather than the sub-batch

## Root Cause

Closedloop transfers are stored in the `transfers` table under the
**parent** `batchId`, not the sub-batch ID. The existing
`evaluateBatchSummary` code was querying by sub-batch ID, finding
nothing, and defaulting totals to zero. Separately, duplicate parent
rows (created by a race condition in the importer) caused JPA's
`getSingleResult()` to throw.

## To verify fix just look in operations-web console , wait until the batch finishes processing and see the correct batch total and details 

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!
- [ ] Followed the PR title naming convention mentioned above.

- [ ] Design related bullet points or design document link related to this PR added in the description above. 

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [ ] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing
